### PR TITLE
Use `static SOURCE` instead of `const SOURCE` in tests.

### DIFF
--- a/src/is_slice.rs
+++ b/src/is_slice.rs
@@ -54,7 +54,7 @@ impl<T, const N: usize> CouldBeSliceOf<T> for &[T; N] {
 mod test {
     use super::*;
 
-    const SOURCE: [i32; 10] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    static SOURCE: [i32; 10] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 
     #[test]
     fn simple() {


### PR DESCRIPTION
`const`s give a new value each time they are evaluated, so `&SOURCE` is not guaranteed to point to the same data as another `&SOURCE` elsewhere in the code.
On the other hand, `static`s exist exactly once in memory.

In particular, `cargo +nightly miri test` used to fail on some tests in this file, but passes under this patch.